### PR TITLE
Add Project.toml for julia v1.5+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,5 @@
 name = "Languages"
 uuid = "54686435-84b5-f32d-7e46-0ea67bb7e12b"
-authors = ["Corneliu Cofaru <cornel@oxoaresearch.com>"]
 version = "0.4.2"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "Languages"
+uuid = "54686435-84b5-f32d-7e46-0ea67bb7e12b"
+authors = ["Corneliu Cofaru <cornel@oxoaresearch.com>"]
+version = "0.4.2"
+
+[deps]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+[compat]
+julia = "1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
Julia `1.5-dev` complains about the package not having a `Project.toml`:
```
 Error: Pkg.Types.PkgError("could not find project file for package `Languages [8ef0a80b]` at `/home/zgornel/.julia/packages/Languages/SxAMm`")
└ @ Pkg.Operations /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/Operations.jl:1385
ERROR: could not find project file for package `Languages [8ef0a80b]` at `/home/zgornel/.julia/packages/Languages/SxAMm`
```
This should provide a minimal working file.