### PR TITLE
Export english name method

### DIFF
--- a/src/Languages.jl
+++ b/src/Languages.jl
@@ -3,7 +3,7 @@ using JSON
 using InteractiveUtils
 
 	export Language
-	export isocode, name, detect
+	export english_name, isocode, name, detect
 	export articles, definite_articles, indefinite_articles
 	export prepositions
 	export pronouns


### PR DESCRIPTION
I would like to use the method `english_name`. Is there a reason why the method `english_name` has not been exported yet?
The other related methods `isocode` and `name` are already exported. What did I miss? Thanks!