### PR TITLE
Update stopwords/German.txt: Add "für"

### DIFF
--- a/data/stopwords/German.txt
+++ b/data/stopwords/German.txt
@@ -89,6 +89,7 @@ eurem
 euren
 eurer
 eures
+für
 gegen
 gewesen
 hab


### PR DESCRIPTION
The preposition "für" (for) is included in the German preposition list, but missing from the stopword list.
Since similar words such as "gegen" (against) or "vor" (before/in front of) are included in the stopword list, I assume the omission of "für" is by mistake.